### PR TITLE
Fix bug with deep copy of image on device

### DIFF
--- a/cuda/cuda_image_container.cpp
+++ b/cuda/cuda_image_container.cpp
@@ -158,7 +158,7 @@ CudaImageContainer::CudaImageContainer(const CudaImageContainer &other)
 
     // Copy the image data over so that this is an independent copy (deep copy).
     cuda_mem_ = std::make_shared<CUDAMemoryWrapper>(size_in_bytes());
-    if (cudaMemcpyAsync(other.cuda_mem_->device_memory(), cuda_mem_->device_memory(), size_in_bytes(),
+    if (cudaMemcpyAsync(cuda_mem_->device_memory(), other.cuda_mem_->device_memory(), size_in_bytes(),
                         cudaMemcpyDeviceToDevice, cuda_stream_->stream()) != cudaSuccess)
     {
         throw std::runtime_error("Failed to copy memory from the GPU");


### PR DESCRIPTION
This PR fixes a bug where the deep copy constructor attempts to copy its own data (empty) to that of the other image. The cudaMemcpyAsync command accepts destination as the first parameter and source as the second one (https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g85073372f776b4c4d5f89f7124b7bf79)